### PR TITLE
Fix CloudFormation Template and use proper Terraform Interpolation

### DIFF
--- a/availability-zones.json
+++ b/availability-zones.json
@@ -1,4 +1,5 @@
-{"TemplateFormatVersion": "2010-09-09",
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
   "Parameters": {},
   "Resources": {
     "DummySecurityGroup": {

--- a/main.tf
+++ b/main.tf
@@ -6,14 +6,14 @@ resource "aws_cloudformation_stack" "availability_zones" {
 }
 
 output "primary" {
-    value = "${ element(split(",", aws_cloudformation_stack.outputs.AvailabilityZones), 0) }"
+    value = "${ element(split(",", aws_cloudformation_stack.availability_zones.outputs.AvailabilityZones), 0) }"
 }
 output "secondary" {
-    value = "${ element(split(",", aws_cloudformation_stack.outputs.AvailabilityZones), 1) }"
+    value = "${ element(split(",", aws_cloudformation_stack.availability_zones.outputs.AvailabilityZones), 1) }"
 }
 output "tertiary" {
-    value = "${ element(split(",", aws_cloudformation_stack.outputs.AvailabilityZones), 2) }"
+    value = "${ element(split(",", aws_cloudformation_stack.availability_zones.outputs.AvailabilityZones), 2) }"
 }
 output "list_all" {
-    value = "${aws_cloudformation_stack.outputs.AvailabilityZones}"
+    value = "${aws_cloudformation_stack.availability_zones.outputs.AvailabilityZones}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,5 @@
 resource "aws_cloudformation_stack" "availability_zones" {
-  count = "${var.enabled}"
   name = "availability-zones"
-  
   template_body = "${file("${path.module}/availability-zones.json")}"
 }
 


### PR DESCRIPTION
The CloudFormation Template, now has a valid syntax and works properly up to date. 
The main.tf, now it's making use of the interpolation syntax. 
The main.tf, now doesn't has a count because it's unnecessary. 
